### PR TITLE
SetupMask mask from child directive

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -36,7 +36,10 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
   _onTouched = () => {}
   _onChange = (_: any) => {}
 
-  constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {}
+  constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {
+    if(this.textMaskConfig.mask.length > 0)
+    this.setupMask(true);
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     this.setupMask(true)

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -37,8 +37,6 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
   _onChange = (_: any) => {}
 
   constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {
-    if(this.textMaskConfig.mask.length > 0)
-    this.setupMask(true);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -84,7 +82,12 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
       }
     }
   }
-
+  
+ protected setup() {
+    if (this.textMaskConfig.mask.length > 0)
+      this.setupMask();
+  } 
+  
   private setupMask(create = false) {
     if (!this.inputElement) {
       if (this.element.nativeElement.tagName === 'INPUT') {

--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -83,12 +83,7 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
     }
   }
   
- protected setup() {
-    if (this.textMaskConfig.mask.length > 0)
-      this.setupMask();
-  } 
-  
-  private setupMask(create = false) {
+  protected setupMask(create = false) {
     if (!this.inputElement) {
       if (this.element.nativeElement.tagName === 'INPUT') {
         // `textMask` directive is used directly on an input element


### PR DESCRIPTION
When I try to extend the mask I have a default mask for phone and I don't need to wait input to setup the mask 

Example : 

@Directive({
  selector: 'input[type=phone]'
})
export class PhoneMaskDirective extends MaskedInputDirective {
  public phoneMask : any[]= ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
  @Input('textMask')
  test:any = this.phoneMask;
  constructor(private elRef : ElementRef,private rendrer :Renderer) {
    super(rendrer,elRef);
    this.textMaskConfig.mask = this.phoneMask;
    }
  }