### PR TITLE
Revert "SetupMask mask from child directive"

### DIFF
--- a/angular2/src/angular2TextMask.ts
+++ b/angular2/src/angular2TextMask.ts
@@ -36,8 +36,7 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
   _onTouched = () => {}
   _onChange = (_: any) => {}
 
-  constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {
-  }
+  constructor(@Inject(Renderer) private renderer: Renderer, @Inject(ElementRef) private element: ElementRef) {}
 
   ngOnChanges(changes: SimpleChanges) {
     this.setupMask(true)
@@ -82,8 +81,8 @@ export class MaskedInputDirective implements ControlValueAccessor, OnChanges {
       }
     }
   }
-  
-  protected setupMask(create = false) {
+
+  private setupMask(create = false) {
     if (!this.inputElement) {
       if (this.element.nativeElement.tagName === 'INPUT') {
         // `textMask` directive is used directly on an input element


### PR DESCRIPTION
Reverts OsamaAbuSitta/text-mask#1 

When I try to extend the mask I have a default mask for phone and I don't need to wait input to setup the mask

Example :

@directive({
selector: 'input[type=phone]'
})
export class PhoneMaskDirective extends MaskedInputDirective {
public phoneMask : any[]= ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
@input('textMask')
test:any = this.phoneMask;
constructor(private elRef : ElementRef,private rendrer :Renderer) {
super(rendrer,elRef);
this.textMaskConfig.mask = this.phoneMask;
}
}